### PR TITLE
Fix iOS not extracting the ERROR_QUERY_KEY from NSError userInfo in t…

### DIFF
--- a/src/ios/Database.h
+++ b/src/ios/Database.h
@@ -1,5 +1,6 @@
 
 #import "./Error.h"
+#import <Foundation/Foundation.h>
 
 @interface Database : NSObject
     - (id _Nonnull) initWithPath:(NSURL*_Nonnull) path openFlags:(int) openFlags busyTimeout:(int) busyTimeout error:(NSError*_Nullable*_Nonnull) error;

--- a/src/ios/Database.mm
+++ b/src/ios/Database.mm
@@ -125,7 +125,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
             code:status
             userInfo:@{
                 NSLocalizedDescriptionKey: [NSString stringWithUTF8String:sqlite3_errstr(status)],
-                ERROR_QUERY_KEY: sql
+                ERROR_DETAILS_KEY: @{
+                    ERROR_QUERY_KEY: sql
+                }
             }
         ];
         sqlite3_finalize(statement);
@@ -160,7 +162,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                 code:status
                 userInfo:@{
                     NSLocalizedDescriptionKey: [NSString stringWithUTF8String:sqlite3_errstr(status)],
-                    ERROR_QUERY_KEY: sql
+                    ERROR_DETAILS_KEY: @{
+                        ERROR_QUERY_KEY: sql
+                    }
                 }
             ];
             sqlite3_finalize(statement);
@@ -245,7 +249,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
             code:status
             userInfo:@{
                 NSLocalizedDescriptionKey: [NSString stringWithUTF8String:sqlite3_errstr(status)],
-                ERROR_QUERY_KEY: chunkSql
+                ERROR_DETAILS_KEY: @{
+                    ERROR_QUERY_KEY: chunkSql
+                }
             }
         ];
         sqlite3_finalize(statement);
@@ -269,7 +275,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                     code:status
                     userInfo:@{
                         NSLocalizedDescriptionKey: [NSString stringWithUTF8String:sqlite3_errstr(status)],
-                        ERROR_QUERY_KEY: chunkSql
+                        ERROR_DETAILS_KEY: @{
+                            ERROR_QUERY_KEY: chunkSql
+                        }
                     }
                 ];
                 sqlite3_finalize(statement);
@@ -293,7 +301,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                 code:status
                 userInfo:@{
                     NSLocalizedDescriptionKey: [NSString stringWithUTF8String:sqlite3_errstr(status)],
-                    ERROR_QUERY_KEY: chunkSql
+                    ERROR_DETAILS_KEY: @{
+                        ERROR_QUERY_KEY: chunkSql
+                    }
                 }
             ];
             return;
@@ -342,7 +352,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                                 "Could not bind parameter \"" + std::string([key UTF8String]) + "\""
                             ).c_str()
                         ],
-                        ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                        ERROR_DETAILS_KEY: @{
+                            ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                        }
                     }
                 ];
                 return;
@@ -395,7 +407,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                             "Unhandled Complex Parameter Object for type \"" + std::string([objType UTF8String]) + "\""
                         ).c_str()
                     ],
-                    ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                    ERROR_DETAILS_KEY: @{
+                        ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                    }
                 }
             ];
             return;
@@ -411,7 +425,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                         "Unhandled Parameter Type for key \"" + std::string([parameterKeyForError UTF8String]) + "\""
                     ).c_str()
                 ],
-                ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                ERROR_DETAILS_KEY: @{
+                    ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                }
             }
         ];
         return;
@@ -423,7 +439,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
             code: status
             userInfo:@{
                 NSLocalizedDescriptionKey: [NSString stringWithUTF8String:sqlite3_errstr(status)],
-                ERROR_QUERY_KEY: [NSString stringWithUTF8String:sqlite3_sql(statement)]
+                ERROR_DETAILS_KEY: @{
+                    ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                }
             }
         ];
         return;
@@ -467,7 +485,9 @@ const NSInteger MAX_VARIABLE_COUNT = 32666;
                             "Unhandled Column Type \"" + std::to_string(columnType) + "\""
                         ).c_str()
                     ],
-                    ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                    ERROR_DETAILS_KEY: @{
+                        ERROR_QUERY_KEY: [NSString stringWithUTF8String: sqlite3_sql(statement)]
+                    }
                 }
             ];
             return nil;

--- a/src/ios/Error.h
+++ b/src/ios/Error.h
@@ -1,4 +1,6 @@
 
+#import <Foundation/Foundation.h>
+
 static NSString * const ERROR_DOMAIN = @"com.totalpave.cordova.sqlite.ErrorDomain";
 static NSString * const ERROR_DETAILS_KEY = @"details";
 static NSString * const ERROR_QUERY_KEY = @"query";

--- a/src/ios/ErrorUtility.h
+++ b/src/ios/ErrorUtility.h
@@ -1,4 +1,6 @@
 
+#import <Foundation/Foundation.h>
+
 @interface ErrorUtility : NSObject
     +(NSDictionary*_Nonnull)errorToDictionary:(NSError*_Nonnull)error;
 @end


### PR DESCRIPTION
…he ErrorUtility.toDictionary API.

Added Foundation.h imports where appropriate. There was inconsistent behaviour regarding these imports. Sometimes xcode will build fine without them, sometimes builds failed because the NS objects are not defined.
I don't understand why it would ever build successfully but ultimately, explicit code is more readable, clear, and does not have this weird problem.
