### PR TITLE
Fixed SQLite restoreBackup not using error string variable in iOS.

### DIFF
--- a/src/android/com/totalpave/cordova/sqlite/SQLite.java
+++ b/src/android/com/totalpave/cordova/sqlite/SQLite.java
@@ -223,6 +223,8 @@ public class SQLite extends CordovaPlugin {
             File source = $parsePath(backupPath);
             File destination = $parsePath(path);
 
+            String userErr = "Could not restore database.";
+
             // Store existing database in case of failure.
             if (!destination.renameTo(tempdestination)) {
                 callback.error(new SqliteException(Error.DOMAIN, "Could not rename existing database.", Error.IO_ERROR).toDictionary());
@@ -231,7 +233,10 @@ public class SQLite extends CordovaPlugin {
 
             // Restore db
             if (!source.renameTo(destination)) {
-                callback.error(new SqliteException(Error.DOMAIN, "Could not restore database.", Error.IO_ERROR).toDictionary());
+                if (!tempdestination.renameTo(destination)) {
+                    userErr += " Also failed to recover from error state.";
+                }
+                callback.error(new SqliteException(Error.DOMAIN, userErr, Error.IO_ERROR).toDictionary());
                 return true;
             }
 

--- a/src/ios/SQLite.m
+++ b/src/ios/SQLite.m
@@ -347,7 +347,7 @@
             initWithDomain: ERROR_DOMAIN
             code: ERROR_CODE_IO
             userInfo:@{
-                NSLocalizedDescriptionKey: @"Could not restore database.",
+                NSLocalizedDescriptionKey: userErr,
                 NSUnderlyingErrorKey: error
             }
         ];


### PR DESCRIPTION
Fixed SQLite restoreBackup not recovering from error state using temp destination in Android.